### PR TITLE
align sample code with readme: set LED to 'breathe' on start

### DIFF
--- a/index.html
+++ b/index.html
@@ -19,6 +19,12 @@
           await device.connect();
           device.addEventListener("temperature", myLogger);
           await device.temperature.start();
+          await device.led.write({
+            mode: "breathe",
+            color: "red",
+            intensity: 50,
+            delay: 1000,
+          });
         } catch (error) {
           console.error(error);
         }


### PR DESCRIPTION
The ["Get started"](https://github.com/NordicPlayground/Nordic-Thingy52-Thingyjs#get-started) section states that Thingy's LED should "breathe" when connected.
But there is no code to activate this behaviour in index.html.
This change adds it.

Other option is to remove the point from the README.